### PR TITLE
Yellowwoodstock patch 1

### DIFF
--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -44,7 +44,7 @@ class GPT2LMScorer(TransformersLMScorer):
         # TODO: Handle overflowing elements for long sentences
         text = list(map(self._add_special_tokens, text))
         encoding: BatchEncoding = self.tokenizer.batch_encode_plus(
-            text, return_tensors="pt", padding=True,
+            text, return_tensors="pt", padding='max_length',
         )
         with torch.no_grad():
             ids = encoding["input_ids"].to(self.model.device)

--- a/lm_scorer/models/gpt2.py
+++ b/lm_scorer/models/gpt2.py
@@ -44,7 +44,7 @@ class GPT2LMScorer(TransformersLMScorer):
         # TODO: Handle overflowing elements for long sentences
         text = list(map(self._add_special_tokens, text))
         encoding: BatchEncoding = self.tokenizer.batch_encode_plus(
-            text, return_tensors="pt",
+            text, return_tensors="pt", padding=True,
         )
         with torch.no_grad():
             ids = encoding["input_ids"].to(self.model.device)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,16 @@ format = "python -m black lm_scorer tests"
 test = "python -m pytest --cov=lm_scorer tests --verbose"
 
 [tool.poetry.dependencies]
-python = ">=3.6,<3.8"
+python = ">=3.6.2,<4.0"
 pip = ">=20.0.0"
-transformers = "^2.9.0"
+transformers = ">=3.0,<5"
 torch = "^1.4.0"
 
 [tool.poetry.dev-dependencies]
 taskipy = "^1.2.1"
 black = "~19.10b0"
 pylint = "^2.5.2"
-mypy = "~0.770"
+mypy = "~0.812"
 pytest = "^5.4.2"
 pytest-cov = "^2.8.1"
 pytest-mock = "^3.0.0"

--- a/tests/unit/models/abc/test_base.py
+++ b/tests/unit/models/abc/test_base.py
@@ -3,6 +3,7 @@ import math
 import pytest  # pylint: disable=unused-import
 
 import scipy
+import scipy.stats
 import torch
 from lm_scorer.models.abc.base import LMScorer
 


### PR DESCRIPTION
Update to allow using more recent version of transformers (tested upto 4.11.3), and can run more recent version of python (tested upto 3.9.7). As previously it lock to transformers version 2.9.x and cause some dependency issue around tokenizers and torch.